### PR TITLE
TOPSIS selector

### DIFF
--- a/src/explainers_lib/aggregators.py
+++ b/src/explainers_lib/aggregators.py
@@ -25,19 +25,28 @@ class AggregatorBase(ABC):
         pass
 
 
-class Pareto(AggregatorBase):
-    """Computes the Pareto front from counterfactuals"""
+class ScoreBasedAggregator(AggregatorBase):
+    """
+    Abstract base class for aggregators that rely on a common set of
+    scores (Proximity, Feasibility, DiscriminativePower).
+    """
 
-    def __init__(self, k_neigh_feasibility = 3, k_neigh_discriminative = 9):
+    def __init__(self, k_neigh_feasibility: int = 3, k_neigh_discriminative: int = 9):
         self.k_neigh_feasibility = k_neigh_feasibility
         self.k_neigh_discriminative = k_neigh_discriminative
+        self.model = None
+        self.data = None
+        self.train_preds = None
 
     def fit(self, model: Model, data: Dataset) -> None:
+        """Fits the aggregator by storing model and training data predictions."""
         self.model = model
         self.data = data
         self.train_preds = self.model.predict(self.data)
 
     def calculate_scores(self, cfs: List[Counterfactual]) -> pd.DataFrame:
+        """Calculates the standard scores for a list of counterfactuals."""
+
         original_data = cfs[0].original_data.reshape(1, -1)
         cfs_data = np.array([cf.data for cf in cfs])
         cfs_target = np.array([cf.target_class for cf in cfs])
@@ -47,21 +56,35 @@ class Pareto(AggregatorBase):
             cf_predicted_classes=cfs_target,
             training_data=self.data.data,
             training_data_predicted_classes=self.train_preds,
-            x = original_data,
+            x=original_data,
             continous_indices=self.data.continuous_features_ids,
             categorical_indices=self.data.categorical_features_ids,
-            k_neighbors_feasib=self.k_neigh_feasibility, 
-            k_neighbors_discriminative=self.k_neigh_discriminative
-            ).reset_index(drop=True)
+            k_neighbors_feasib=self.k_neigh_feasibility,
+            k_neighbors_discriminative=self.k_neigh_discriminative,
+        ).reset_index(drop=True)
+
+    @abstractmethod
+    def __call__(self, cfs: List[Counterfactual]) -> List[Counterfactual]:
+        pass
+
+
+class Pareto(ScoreBasedAggregator):
+    """Computes the Pareto front from counterfactuals"""
+
+    def __init__(self, k_neigh_feasibility=3, k_neigh_discriminative=9):
+        super().__init__(
+            k_neigh_feasibility=k_neigh_feasibility,
+            k_neigh_discriminative=k_neigh_discriminative,
+        )
 
     def __call__(self, cfs: List[Counterfactual]) -> List[Counterfactual]:
         scores = self.calculate_scores(cfs)
 
         # Example: return all Pareto-efficient counterfactuals
-        x_metric = 'Proximity'
-        y_metric = 'K_Feasibility(3)'
-        z_metric = 'DiscriminativePower(9)'
-        optimization_direction = ['min', 'min', 'max']
+        x_metric = "Proximity"
+        y_metric = "K_Feasibility(3)"
+        z_metric = "DiscriminativePower(9)"
+        optimization_direction = ["min", "min", "max"]
 
         all_x = scores[x_metric].to_numpy()
         all_y = scores[y_metric].to_numpy()
@@ -69,8 +92,7 @@ class Pareto(AggregatorBase):
         to_check = np.array([all_x, all_y, all_z], dtype=np.float64).T
 
         pareto_mask = get_pareto_optimal_mask(
-            data=to_check,
-            optimization_direction=optimization_direction
+            data=to_check, optimization_direction=optimization_direction
         ).astype(bool)
 
         pareto_indices = np.where(pareto_mask)[0]
@@ -78,23 +100,32 @@ class Pareto(AggregatorBase):
         return pareto_cfs
 
 
-class IdealPoint(Pareto):
+class IdealPoint(ScoreBasedAggregator):
     """Computes the ideal point from counterfactuals"""
-    def __init__(self, weights: List[float] = None, k_neigh_feasibility = 3, k_neigh_discriminative = 9):
+
+    def __init__(
+        self,
+        weights: List[float] = None,
+        k_neigh_feasibility=3,
+        k_neigh_discriminative=9,
+    ):
         """
         weights: optional list of 3 weights for x, y, z metrics
         (will be normalized to sum = 1). If None, equal weights are used.
         """
-        super().__init__(k_neigh_feasibility=k_neigh_feasibility, k_neigh_discriminative=k_neigh_discriminative)
+        super().__init__(
+            k_neigh_feasibility=k_neigh_feasibility,
+            k_neigh_discriminative=k_neigh_discriminative,
+        )
         self.weights = weights
 
     def __call__(self, cfs: List[Counterfactual]) -> List[Counterfactual]:
         scores = self.calculate_scores(cfs)
 
-        x_metric = 'Proximity'
-        y_metric = 'K_Feasibility(3)'
-        z_metric = 'DiscriminativePower(9)'
-        optimization_direction = ['min', 'min', 'max']
+        x_metric = "Proximity"
+        y_metric = "K_Feasibility(3)"
+        z_metric = "DiscriminativePower(9)"
+        optimization_direction = ["min", "min", "max"]
 
         all_x = scores[x_metric].to_numpy()
         all_y = scores[y_metric].to_numpy()
@@ -102,10 +133,9 @@ class IdealPoint(Pareto):
         to_check = np.array([all_x, all_y, all_z], dtype=np.float64).T
 
         pareto_mask = get_pareto_optimal_mask(
-            data=to_check,
-            optimization_direction=optimization_direction
+            data=to_check, optimization_direction=optimization_direction
         ).astype(bool)
-        
+
         pareto_indices = np.where(pareto_mask)[0]
         pareto_cfs = [cfs[i] for i in pareto_indices]
         pareto_data = to_check[pareto_mask]
@@ -125,24 +155,26 @@ class IdealPoint(Pareto):
         best_idx = np.argmin(dists)
         return [pareto_cfs[best_idx]]
 
-    
-class BalancedPoint(Pareto):
+
+class BalancedPoint(ScoreBasedAggregator):
     """
     Selects a single counterfactual closest to the midpoint between the ideal and nadir points
     (i.e., a balanced trade-off solution).
     """
 
     def __init__(self, k_neigh_feasibility=3, k_neigh_discriminative=9):
-        super().__init__(k_neigh_feasibility=k_neigh_feasibility,
-                         k_neigh_discriminative=k_neigh_discriminative)
+        super().__init__(
+            k_neigh_feasibility=k_neigh_feasibility,
+            k_neigh_discriminative=k_neigh_discriminative,
+        )
 
     def __call__(self, cfs: List[Counterfactual]) -> List[Counterfactual]:
         scores = self.calculate_scores(cfs)
 
-        x_metric = 'Proximity'
-        y_metric = 'K_Feasibility(3)'
-        z_metric = 'DiscriminativePower(9)'
-        optimization_direction = ['min', 'min', 'max']
+        x_metric = "Proximity"
+        y_metric = "K_Feasibility(3)"
+        z_metric = "DiscriminativePower(9)"
+        optimization_direction = ["min", "min", "max"]
 
         all_x = scores[x_metric].to_numpy()
         all_y = scores[y_metric].to_numpy()
@@ -150,10 +182,9 @@ class BalancedPoint(Pareto):
         to_check = np.array([all_x, all_y, all_z], dtype=np.float64).T
 
         pareto_mask = get_pareto_optimal_mask(
-            data=to_check,
-            optimization_direction=optimization_direction
+            data=to_check, optimization_direction=optimization_direction
         ).astype(bool)
-        
+
         pareto_indices = np.where(pareto_mask)[0]
         pareto_cfs = [cfs[i] for i in pareto_indices]
         pareto_data = to_check[pareto_mask]
@@ -161,10 +192,13 @@ class BalancedPoint(Pareto):
         # Compute ideal and nadir points
         ideal_point = get_ideal_point(to_check, optimization_direction, pareto_mask)
 
-        nadir_point = np.array([
-            np.max(pareto_data[:, i]) if opt == 'min' else np.min(pareto_data[:, i])
-            for i, opt in enumerate(optimization_direction)
-        ], dtype=np.float64)
+        nadir_point = np.array(
+            [
+                np.max(pareto_data[:, i]) if opt == "min" else np.min(pareto_data[:, i])
+                for i, opt in enumerate(optimization_direction)
+            ],
+            dtype=np.float64,
+        )
 
         # Midpoint between ideal and nadir (balanced region)
         midpoint = (ideal_point + nadir_point) / 2
@@ -175,7 +209,93 @@ class BalancedPoint(Pareto):
 
         return [pareto_cfs[best_idx]]
 
-    
+
+class TOPSIS(ScoreBasedAggregator):
+    """
+    Selects the top-k counterfactuals using the TOPSIS
+    (Technique for Order of Preference by Similarity to Ideal Solution) method.
+    <see: https://www.researchgate.net/publication/285886027_Notes_on_TOPSIS_Method>
+    """
+
+    def __init__(
+        self,
+        k: int = 1,
+        k_neigh_feasibility=3,
+        k_neigh_discriminative=9,
+    ):
+        """
+        Parameters
+        ----------
+        k : int
+            Number of top counterfactuals to return.
+        """
+        super().__init__(
+            k_neigh_feasibility=k_neigh_feasibility,
+            k_neigh_discriminative=k_neigh_discriminative,
+        )
+        self.weights = None
+        self.k = k
+
+    def __call__(self, cfs: List[Counterfactual]) -> List[Counterfactual]:
+        if not cfs or len(cfs) < 1:
+            return []
+
+        scores = self.calculate_scores(cfs)
+        if scores.empty:
+            return []
+
+        criteria_cols = [
+            "Proximity",
+            "K_Feasibility(3)",
+            "DiscriminativePower(9)",
+        ]
+        optimization_direction = ["min", "min", "max"]
+
+        matrix = scores[criteria_cols].to_numpy(dtype=np.float64)
+
+        if self.weights is None:
+            weights = np.ones(matrix.shape[1]) / matrix.shape[1]
+        else:
+            if len(self.weights) != matrix.shape[1]:
+                raise ValueError(
+                    f"List of weight's length ({len(self.weights)}) must "
+                    f"match number of criteria ({matrix.shape[1]})"
+                )
+            weights = np.array(self.weights, dtype=float)
+            weights = weights / weights.sum()
+
+        norms = np.linalg.norm(matrix, axis=0)
+        norms[norms == 0] = np.finfo(float).eps
+        normalized_matrix = matrix / norms
+
+        weighted_matrix = normalized_matrix * weights
+
+        col_maxes = np.max(weighted_matrix, axis=0)
+        col_mins = np.min(weighted_matrix, axis=0)
+
+        is_max_direction = np.array(optimization_direction) == "max"
+
+        ideal_solution = np.where(is_max_direction, col_maxes, col_mins)
+        anti_ideal_solution = np.where(is_max_direction, col_mins, col_maxes)
+
+        dist_to_ideal = np.linalg.norm(weighted_matrix - ideal_solution, axis=1)
+        dist_to_anti_ideal = np.linalg.norm(
+            weighted_matrix - anti_ideal_solution, axis=1
+        )
+
+        denominator = dist_to_ideal + dist_to_anti_ideal
+        denominator[denominator == 0] = np.finfo(float).eps
+        closeness_score = dist_to_anti_ideal / denominator
+
+        ranked_indices = np.argsort(closeness_score)[::-1]
+
+        top_k_indices = ranked_indices[: self.k]
+
+        selected_cfs = [cfs[i] for i in top_k_indices]
+
+        return selected_cfs
+
+
 class DensityBased(AggregatorBase):
     """Selects k diverse-yet-similar counterfactuals using a density-based objective (Cost Scaled Greedy)."""
 

--- a/src/explainers_lib/ensemble.py
+++ b/src/explainers_lib/ensemble.py
@@ -4,7 +4,7 @@ from .model import Model
 from .explainers import Explainer
 from .explainers.celery_remote import app, try_get_available_explainers
 from .explainers.celery_explainer import CeleryExplainer
-from .aggregators import Aggregator, All, Pareto
+from .aggregators import Aggregator, All, ScoreBasedAggregator
 from .counterfactual import Counterfactual
 from .datasets import Dataset
 import numpy as np
@@ -49,7 +49,7 @@ class Ensemble:
         for explainer in self.explainers:
             explainer.fit(self.model, data)
 
-        if isinstance(self.aggregator, Pareto):
+        if isinstance(self.aggregator, ScoreBasedAggregator):
             self.aggregator.fit(self.model, data)
 
         if task:


### PR DESCRIPTION
- Introduced `ScoreBasedAggregator` as an abstract base class for aggregators that use common scoring criteria

- Refactored `Pareto`, `IdealPoint`, and `BalancedPoint` to inherit from `ScoreBasedAggregator` 

-  Added the `TOPSIS` aggregator, which selects the top-k counterfactuals using the TOPSIS method

### Example for k=1
```
Used celery explainers: ['carla_actionable_recourse', 'carla_dice', 'carla_face', 'alibi_cfproto', 'alibi_cfrl']
Ensemble fitting complete
5instance [00:00, 14.74instance/s]
5instance [00:07,  1.50s/instance]
┏━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━┳━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
┃ sepal length (cm) ┃ sepal width (cm) ┃ petal length (cm) ┃ petal width (cm) ┃ target ┃ source                                                                                      ┃
┡━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━╇━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┩
│            6.0000 │           2.9000 │            4.5000 │           1.5000 │      1 │ original data                                                                               │
│               N/A │              N/A │               N/A │              N/A │    N/A │ actionable_recourse(flip_size=1000)                                                         │
│               N/A │              N/A │               N/A │              N/A │    N/A │ cfproto()                                                                                   │
│            6.2451 │           3.2214 │            4.7061 │           1.5684 │      1 │ cfrl(latent_dim=2, coeff_sparsity=0.5, coeff_consistency=0.5, train_steps=3, batch_size=10) │
│               N/A │              N/A │               N/A │              N/A │    N/A │ dice_explainer(num_cfs=1, method='random')                                                  │
│               N/A │              N/A │               N/A │              N/A │    N/A │ face_explainer(mode=knn, fraction=0.05, n_neighbors=50)                                     │
│               N/A │              N/A │               N/A │              N/A │    N/A │ growing_spheres(step_size=0.1, max_radius=5.0, num_samples=1000)                            │
│               N/A │              N/A │               N/A │              N/A │    N/A │ wachter(lambda_param=0.1, random_seed=None)                                                 │
├───────────────────┼──────────────────┼───────────────────┼──────────────────┼────────┼─────────────────────────────────────────────────────────────────────────────────────────────┤
│            6.1000 │           2.8000 │            4.7000 │           1.2000 │      1 │ original data                                                                               │
│               N/A │              N/A │               N/A │              N/A │    N/A │ actionable_recourse(flip_size=1000)                                                         │
│               N/A │              N/A │               N/A │              N/A │    N/A │ cfproto()                                                                                   │
│               N/A │              N/A │               N/A │              N/A │    N/A │ cfrl(latent_dim=2, coeff_sparsity=0.5, coeff_consistency=0.5, train_steps=3, batch_size=10) │
│               N/A │              N/A │               N/A │              N/A │    N/A │ dice_explainer(num_cfs=1, method='random')                                                  │
│               N/A │              N/A │               N/A │              N/A │    N/A │ face_explainer(mode=knn, fraction=0.05, n_neighbors=50)                                     │
│            6.1390 │           2.8113 │            5.3070 │           1.4660 │      2 │ growing_spheres(step_size=0.1, max_radius=5.0, num_samples=1000)                            │
│               N/A │              N/A │               N/A │              N/A │    N/A │ wachter(lambda_param=0.1, random_seed=None)                                                 │
├───────────────────┼──────────────────┼───────────────────┼──────────────────┼────────┼─────────────────────────────────────────────────────────────────────────────────────────────┤
│            5.7000 │           3.8000 │            1.7000 │           0.3000 │      0 │ original data                                                                               │
│               N/A │              N/A │               N/A │              N/A │    N/A │ actionable_recourse(flip_size=1000)                                                         │
│               N/A │              N/A │               N/A │              N/A │    N/A │ cfproto()                                                                                   │
│            6.2110 │           3.2118 │            4.3583 │           1.4993 │      1 │ cfrl(latent_dim=2, coeff_sparsity=0.5, coeff_consistency=0.5, train_steps=3, batch_size=10) │
│               N/A │              N/A │               N/A │              N/A │    N/A │ dice_explainer(num_cfs=1, method='random')                                                  │
│               N/A │              N/A │               N/A │              N/A │    N/A │ face_explainer(mode=knn, fraction=0.05, n_neighbors=50)                                     │
│               N/A │              N/A │               N/A │              N/A │    N/A │ growing_spheres(step_size=0.1, max_radius=5.0, num_samples=1000)                            │
│               N/A │              N/A │               N/A │              N/A │    N/A │ wachter(lambda_param=0.1, random_seed=None)                                                 │
├───────────────────┼──────────────────┼───────────────────┼──────────────────┼────────┼─────────────────────────────────────────────────────────────────────────────────────────────┤
│            6.8000 │           2.8000 │            4.8000 │           1.4000 │      1 │ original data                                                                               │
│               N/A │              N/A │               N/A │              N/A │    N/A │ actionable_recourse(flip_size=1000)                                                         │
│               N/A │              N/A │               N/A │              N/A │    N/A │ cfproto()                                                                                   │
│               N/A │              N/A │               N/A │              N/A │    N/A │ cfrl(latent_dim=2, coeff_sparsity=0.5, coeff_consistency=0.5, train_steps=3, batch_size=10) │
│               N/A │              N/A │               N/A │              N/A │    N/A │ dice_explainer(num_cfs=1, method='random')                                                  │
│               N/A │              N/A │               N/A │              N/A │    N/A │ face_explainer(mode=knn, fraction=0.05, n_neighbors=50)                                     │
│            6.8460 │           2.8434 │            5.3456 │           1.5670 │      2 │ growing_spheres(step_size=0.1, max_radius=5.0, num_samples=1000)                            │
│               N/A │              N/A │               N/A │              N/A │    N/A │ wachter(lambda_param=0.1, random_seed=None)                                                 │
├───────────────────┼──────────────────┼───────────────────┼──────────────────┼────────┼─────────────────────────────────────────────────────────────────────────────────────────────┤
│            7.7000 │           2.6000 │            6.9000 │           2.3000 │      2 │ original data                                                                               │
│               N/A │              N/A │               N/A │              N/A │    N/A │ actionable_recourse(flip_size=1000)                                                         │
│            6.3310 │           2.7886 │            4.8197 │           1.6476 │      1 │ cfproto()                                                                                   │
│               N/A │              N/A │               N/A │              N/A │    N/A │ cfrl(latent_dim=2, coeff_sparsity=0.5, coeff_consistency=0.5, train_steps=3, batch_size=10) │
│               N/A │              N/A │               N/A │              N/A │    N/A │ dice_explainer(num_cfs=1, method='random')                                                  │
│               N/A │              N/A │               N/A │              N/A │    N/A │ face_explainer(mode=knn, fraction=0.05, n_neighbors=50)                                     │
│               N/A │              N/A │               N/A │              N/A │    N/A │ growing_spheres(step_size=0.1, max_radius=5.0, num_samples=1000)                            │
│               N/A │              N/A │               N/A │              N/A │    N/A │ wachter(lambda_param=0.1, random_seed=None)                                                 │
└───────────────────┴──────────────────┴───────────────────┴──────────────────┴────────┴─────────────────────────────────────────────────────────────────────────────────────────────┘
Number of generated cfs: 5
```

Closes #49