### PR TITLE
Handle categorical data in DiCE explainer

### DIFF
--- a/explainers/dice/requirements.minimal.txt
+++ b/explainers/dice/requirements.minimal.txt
@@ -5,5 +5,3 @@ scipy>=1.0.0
 torch==2.7.0+cpu
 
 dice-ml==0.12
-
-setuptools<58.0.0


### PR DESCRIPTION
DiCE should work on the original dataframe (without OHE). This PR implements that allowing DiCE to handle categorical data. `setuptools<58.0.0` dropped from requirements because it makes no sense.