### PR TITLE
Make CFProto generate k-best counterfactuals

### DIFF
--- a/explainers/alibi/cfproto.py
+++ b/explainers/alibi/cfproto.py
@@ -17,9 +17,10 @@ from explainers_lib import Explainer, Dataset, Model, Counterfactual
 
 # note: This explainer does not support immutable features
 class CFProto(Explainer):
-    def __init__(self):
+    def __init__(self, k=1):
         self.cf = None
         self.safe_k = 1 # Fallback
+        self.k = k
 
     def fit(self, model: Model, data: Dataset) -> None:
         print(f"CFProto: Fitting on {len(data.data)} samples.")
@@ -136,20 +137,47 @@ class CFProto(Explainer):
                 log_every=100)
             
             if explanation.cf is not None:
-                cf_data = explanation.cf["X"][0]
-                cf_class = model.predict(np.expand_dims(cf_data, axis=0))[0]
+                best_cf_data = explanation.cf["X"]
+                
+                unique_cfs = [best_cf_data]
+                seen_hashes = {best_cf_data.tobytes()}
+                
+                if self.k > 1 and explanation.all:
+                    all_found_cfs = []
+                    for iteration, cfs_in_iter in explanation.all.items():
+                        all_found_cfs.extend(cfs_in_iter)
+                    
+                    # Sort runners-up by L1 distance to the original instance
+                    sorted_cfs = sorted(
+                        all_found_cfs, 
+                        key=lambda c: np.linalg.norm(c.flatten() - instance.flatten(), ord=1)
+                    )
+                    
+                    for c in sorted_cfs:
+                        if len(unique_cfs) >= self.k:
+                            break
+                            
+                        cf_bytes = c.tobytes()
+                        if cf_bytes not in seen_hashes:
+                            seen_hashes.add(cf_bytes)
+                            unique_cfs.append(c)
 
-                cfs.append(Counterfactual(
-                    instance,
-                    cf_data,
-                    instance_class,
-                    cf_class,
-                    repr(self)
-                ))
+                for cf_data_array in unique_cfs:
+                    cf_data_flat = cf_data_array[0]
+                    cf_class = model.predict(np.expand_dims(cf_data_flat, axis=0))[0]
+
+                    cfs.append(Counterfactual(
+                        instance,
+                        cf_data_flat,
+                        instance_class,
+                        cf_class,
+                        repr(self)
+                    ))
+
         return cfs
 
     def __repr__(self) -> str:
-        return "cfproto()" # TODO: make the hyperparameters configurable
+        return f"cfproto(k={repr(self.k)})" # TODO: make the hyperparameters configurable
 
 explainer = CFProto()
 create_celery_tasks(explainer, "alibi_cfproto")


### PR DESCRIPTION
```console
/examples> python explainer.py
┏━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━┳━━━━━━━━┳━━━━━━━━━━━━━━━┓
┃ petal length (cm) ┃ sepal length (cm) ┃ petal width (cm) ┃ sepal width (cm) ┃ target ┃ source        ┃
┡━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━╇━━━━━━━━╇━━━━━━━━━━━━━━━┩
│            4.7000 │            6.1000 │           1.2000 │           2.8000 │      1 │ original data │
│            4.9460 │            6.1010 │           1.8070 │           2.8000 │      2 │ cfproto(k=4)  │
│            4.9612 │            6.1079 │           1.8137 │           2.8000 │      2 │ cfproto(k=4)  │
│            4.9753 │            6.1144 │           1.8199 │           2.8000 │      2 │ cfproto(k=4)  │
│            4.9886 │            6.1205 │           1.8257 │           2.8000 │      2 │ cfproto(k=4)  │
├───────────────────┼───────────────────┼──────────────────┼──────────────────┼────────┼───────────────┤
│            1.7000 │            5.7000 │           0.3000 │           3.8000 │      0 │ original data │
│            3.2213 │            5.8449 │           1.0763 │           3.6056 │      1 │ cfproto(k=4)  │
│            3.4365 │            5.7488 │           1.0947 │           3.5663 │      1 │ cfproto(k=4)  │
│            5.7699 │            6.7768 │           2.0182 │           3.0715 │      2 │ cfproto(k=4)  │
│            5.8335 │            6.7696 │           2.0316 │           3.0590 │      2 │ cfproto(k=4)  │
├───────────────────┼───────────────────┼──────────────────┼──────────────────┼────────┼───────────────┤
│            6.9000 │            7.7000 │           2.3000 │           2.6000 │      2 │ original data │
│            5.3428 │            7.0608 │           1.6400 │           2.6849 │      1 │ cfproto(k=4)  │
│            5.3489 │            7.0513 │           1.6415 │           2.6877 │      1 │ cfproto(k=4)  │
│            5.3403 │            7.0473 │           1.6377 │           2.6895 │      1 │ cfproto(k=4)  │
│            5.3321 │            7.0436 │           1.6341 │           2.6912 │      1 │ cfproto(k=4)  │
├───────────────────┼───────────────────┼──────────────────┼──────────────────┼────────┼───────────────┤
│            4.5000 │            6.0000 │           1.5000 │           2.9000 │      1 │ original data │
│            4.9952 │            6.1126 │           1.8314 │           2.9000 │      2 │ cfproto(k=4)  │
│            4.9991 │            6.1253 │           1.8342 │           2.9000 │      2 │ cfproto(k=4)  │
│            5.0109 │            6.1307 │           1.8394 │           2.9000 │      2 │ cfproto(k=4)  │
│            5.0220 │            6.1358 │           1.8443 │           2.9000 │      2 │ cfproto(k=4)  │
├───────────────────┼───────────────────┼──────────────────┼──────────────────┼────────┼───────────────┤
│            4.8000 │            6.8000 │           1.4000 │           2.8000 │      1 │ original data │
│            5.0021 │            6.6747 │           1.8332 │           2.8000 │      2 │ cfproto(k=4)  │
│            5.0138 │            6.6693 │           1.8384 │           2.8000 │      2 │ cfproto(k=4)  │
│            5.0250 │            6.6642 │           1.8433 │           2.8000 │      2 │ cfproto(k=4)  │
│            5.0355 │            6.6594 │           1.8479 │           2.8000 │      2 │ cfproto(k=4)  │
└───────────────────┴───────────────────┴──────────────────┴──────────────────┴────────┴───────────────┘
```